### PR TITLE
Fix packaging (ref: LinuxCNC/linuxcnc#1018).

### DIFF
--- a/scripts/package/builddeb
+++ b/scripts/package/builddeb
@@ -58,6 +58,9 @@ um)
 parisc|mips|powerpc)
 	installed_image_path="boot/vmlinux-$version"
 	;;
+arm)
+	installed_image_path="boot/kernel7l.img"
+	;;
 *)
 	installed_image_path="boot/vmlinuz-$version"
 esac

--- a/scripts/package/mkdebian
+++ b/scripts/package/mkdebian
@@ -175,7 +175,9 @@ Homepage: http://www.kernel.org/
 
 Package: $packagename
 Architecture: $debarch
-Conflicts: raspberrpi-kernel
+Provides: linux-image
+Conflicts: linux-image
+Replaces: linux-image
 Description: Linux kernel, version $version
  This package contains the Linux kernel, modules and corresponding other
  files, version: $version.


### PR DESCRIPTION
The change includes:
1) Use `Provides`, `Conflicts`, `Replaces` to ensure only one `linux-image` package can be installed (see [Debian policy recommendation](https://www.debian.org/doc/debian-policy/ch-relationships.html#replacing-whole-packages-forcing-their-removal)).
2) Rename kernel image to `/boot/kernel7l.img`. RPi 4B bootloader loads this file after start.

See previously discussion: LinuxCNC/linuxcnc#1018

I've tested deb-package and RPi4 boots without any problem.

I use cross-compilation to build deb-package:
```
export ARCH=arm
export CROSS_COMPILE=arm-linux-gnueabihf-
make clean
make bcm2711_defconfig
make bindeb-pkg
```
